### PR TITLE
fix(gradle): compatibility range is `223.0 — 223.*`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ tasks {
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
-        // untilBuild.set(properties("pluginUntilBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.1.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-# pluginUntilBuild = 251.*
+pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
I received an email from JetBrains, which states that now you don't need to set pluginUntilBuild.
But according to the actual situation, it doesn't work 🤷

<img width="3580" height="2424" alt="CleanShot 2025-09-05 at 22 01 43" src="https://github.com/user-attachments/assets/d5cc95ea-82ee-4df5-b7e0-66f594fe4fdc" />

Fix: #48